### PR TITLE
dynamic controllers

### DIFF
--- a/addon/services/slides2.js
+++ b/addon/services/slides2.js
@@ -1,10 +1,14 @@
 import Service, { inject as service } from '@ember/service';
 import Object from '@ember/object';
+import Controller from '@ember/controller';
 import { mapBy, readOnly } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import { A } from '@ember/array';
 import { on } from '@ember/object/evented';
+import { getOwner } from '@ember/application';
 import { EKMixin as EmberKeyboard, keyUp } from 'ember-keyboard';
+
+import slideControllerTemplate from 'ember-present/templates/slide-controller';
 
 const Slide = Object.extend({
   path: undefined,
@@ -19,6 +23,7 @@ const SlideTransition = Object.extend({
 
 export default Service.extend(EmberKeyboard, {
   router: service(),
+  session2: service(),
 
   slideRoutes: undefined,
   roles: undefined,
@@ -35,6 +40,18 @@ export default Service.extend(EmberKeyboard, {
     this.get('slideRoutes').pushObject(
       Slide.create({ path, config })
     );
+
+    let owner = getOwner(this);
+    let containerPath = path.replace('.', '/');
+
+    let SlideController = Controller.extend({
+      session2: service(),
+
+      name: containerPath
+    });
+
+    owner.register(`controller:${containerPath}`, SlideController);
+    owner.register(`template:${containerPath}`, slideControllerTemplate);
   },
 
   registerRole(name, config) {

--- a/addon/templates/slide-controller.hbs
+++ b/addon/templates/slide-controller.hbs
@@ -1,0 +1,1 @@
+<h4>Slide controller: {{name}}: {{session2.role}}</h4>

--- a/tests/dummy/app/controllers/slides/auth/slide-1.js
+++ b/tests/dummy/app/controllers/slides/auth/slide-1.js
@@ -1,6 +1,0 @@
-import Controller from '@ember/controller';
-import { inject } from '@ember/service';
-
-export default Controller.extend({
-  session2: inject()
-});

--- a/tests/dummy/app/controllers/slides/auth/slide-2.js
+++ b/tests/dummy/app/controllers/slides/auth/slide-2.js
@@ -1,6 +1,0 @@
-import Controller from '@ember/controller';
-import { inject } from '@ember/service';
-
-export default Controller.extend({
-  session2: inject()
-});

--- a/tests/dummy/app/templates/login.hbs
+++ b/tests/dummy/app/templates/login.hbs
@@ -53,4 +53,4 @@
   </h3>
 {{/unless}}
 
-<h3 class="p-4">Or try the {{#link-to 'slides.slide-1'}}WIP slides{{/link-to}} which use the v1 architecture</h3>
+<h3 class="p-4">Or try the {{#link-to 'slides.auth.slide-1'}}WIP slides{{/link-to}} which use the v1 architecture</h3>


### PR DESCRIPTION
Auto registering controller and templates for slides so that we can use slide routes with components automatically. We may find that allowing custom controllers are useful later, in that case we'll allow them to be defined