### PR TITLE
check multiple locations for slide components

### DIFF
--- a/addon/models/slide.js
+++ b/addon/models/slide.js
@@ -16,7 +16,10 @@ export default Object.extend({
     return this.get('path').replace(/\./g, '/');
   }),
 
-  getRoleComponentPath(role) {
-    return `slides/${role.name}/${this.get('componentName')}`;
+  getRoleComponentPaths(role) {
+    return [
+      `slides/${this.get('componentName')}/${role.name}`,
+      `slides/${role.name}/${this.get('componentName')}`,
+    ];
   },
 });

--- a/addon/services/slides.js
+++ b/addon/services/slides.js
@@ -53,8 +53,8 @@ export default Service.extend(EmberKeyboard, {
     owner.register(`template:${containerPath}`, slideControllerTemplate);
 
     this.get('roles').forEach(role => {
-      let componentPath = slide.getRoleComponentPath(role);
-      if (!this._componentExists(componentPath)) {
+      let componentPaths = slide.getRoleComponentPaths(role);
+      if (!this._componentExists(componentPaths)) {
         slide.set(`${role.name}SlideIsMissing`, true);
       }
     });
@@ -205,8 +205,16 @@ export default Service.extend(EmberKeyboard, {
     },
   },
 
-  _componentExists(componentPath) {
-    let template = getOwner(this).lookup(`template:components/${componentPath}`);
-    return !!template;
+  _componentExists(componentPaths) {
+    let owner = getOwner(this);
+
+    for (let componentPath of componentPaths) {
+      let template = owner.lookup(`template:components/${componentPath}`);
+      if (template) {
+        return true;
+      }
+    }
+
+    return false;
   },
 });

--- a/addon/templates/components/x-responsive-slide-content.hbs
+++ b/addon/templates/components/x-responsive-slide-content.hbs
@@ -1,4 +1,4 @@
-<div class="bg-blue min-h-screen">
+<div class="bg-black min-h-screen">
   {{yield
     (hash
       button=(component 'x-button')


### PR DESCRIPTION
This allows us to optionally co-locate slides for pods apps:

```
components/slides/slide-1/screen/template.hbs
components/slides/slide-1/presenter/template.hbs
components/slides/slide-1/presenter/component.js
```